### PR TITLE
Ror 594

### DIFF
--- a/mobi.chouette.common/src/main/java/mobi/chouette/common/parallel/ParallelExecutionCommand.java
+++ b/mobi.chouette.common/src/main/java/mobi/chouette/common/parallel/ParallelExecutionCommand.java
@@ -134,6 +134,6 @@ public class ParallelExecutionCommand implements Command {
 
 	static {
 		CommandFactory.factories.put(ParallelExecutionCommand.class.getName(),
-				new DefaultCommandFactory());
+				new ParallelExecutionCommand.DefaultCommandFactory());
 	}
 }

--- a/mobi.chouette.common/src/main/java/mobi/chouette/common/parallel/ParallelExecutionCommand.java
+++ b/mobi.chouette.common/src/main/java/mobi/chouette/common/parallel/ParallelExecutionCommand.java
@@ -46,7 +46,10 @@ public class ParallelExecutionCommand implements Command {
 	public boolean execute(Context context) throws Exception {
 
 		if (context == null) {
-			throw new IllegalArgumentException();
+			throw new IllegalArgumentException("Context is null");
+		}
+		if (commands.size() == 0) {
+			throw new IllegalStateException("No command to execute");
 		}
 		boolean result = SUCCESS;
 		Monitor monitor = MonitorFactory.start(COMMAND);
@@ -131,6 +134,6 @@ public class ParallelExecutionCommand implements Command {
 
 	static {
 		CommandFactory.factories.put(ParallelExecutionCommand.class.getName(),
-				new ParallelExecutionCommand.DefaultCommandFactory());
+				new DefaultCommandFactory());
 	}
 }

--- a/mobi.chouette.exchange.netexprofile/pom.xml
+++ b/mobi.chouette.exchange.netexprofile/pom.xml
@@ -33,7 +33,6 @@
 		<dependency>
 			<groupId>org.entur.helpers</groupId>
 			<artifactId>calendar-helper</artifactId>
-			<version>0.0.3-SNAPSHOT</version>
 		</dependency>
 <dependency>
     <groupId>net.sf.saxon</groupId>


### PR DESCRIPTION
- improved validation error message when a dataset containing no line definition is imported,
- improved error message in ParallelExecutionCommand when the list of commands is empty
- fixed snapshot dependency on calendar-helper in pom.xml