### PR TITLE
Removed memory  check in live probe

### DIFF
--- a/mobi.chouette.service/src/main/java/mobi/chouette/service/HealthService.java
+++ b/mobi.chouette.service/src/main/java/mobi/chouette/service/HealthService.java
@@ -15,40 +15,11 @@ public class HealthService {
 
 	public static final String BEAN_NAME = "HealthService";
 
-	// Check memory for every Xth liveness check
-	private static final int CHECK_MEMORY_FREQUENCY = 10;
-
-	// Require 500 mb to allocated to verify application has enough memory
-	private static final int CHECK_MEMORY_BYTES_SIZE = 500 * 1000 * 1024;
-
-	private int checkMemoryCnt = 0;
-
 	@EJB
 	private DbStatusChecker dbStatusChecker;
 
 	public boolean isReady() {
-		log.debug("Checking readiness...");
 		return dbStatusChecker.isDbUp();
-	}
-
-	public boolean isLive() {
-		if (++checkMemoryCnt >= CHECK_MEMORY_FREQUENCY) {
-			checkMemoryCnt = 0;
-			return checkMemory();
-		}
-		return true;
-	}
-
-
-	private boolean checkMemory() {
-		boolean ok = false;
-		try {
-			byte[] bytes = new byte[CHECK_MEMORY_BYTES_SIZE];
-			ok = true;
-		} catch (Throwable t) {
-			log.fatal("Failed to allocate " + CHECK_MEMORY_BYTES_SIZE + " bytes for memory check. Liveness test failed, should cause application to be shut down.");
-		}
-		return ok;
 	}
 
 }

--- a/mobi.chouette.ws/src/main/java/mobi/chouette/ws/HealthResource.java
+++ b/mobi.chouette.ws/src/main/java/mobi/chouette/ws/HealthResource.java
@@ -36,11 +36,7 @@ public class HealthResource {
 	@Path("/live")
 	public Response isLive() {
 		log.debug("Checking liveness...");
-		if (healthService.isLive()) {
-			return Response.ok().build();
-		} else {
-			return Response.serverError().build();
-		}
+		return Response.ok().build();
 	}
 
 	@GET


### PR DESCRIPTION
The memory check triggers full GCs by trying to allocate a large byte array.